### PR TITLE
fixing the issue with footer on Chrome

### DIFF
--- a/src/components/layout/menu/menu.css.js
+++ b/src/components/layout/menu/menu.css.js
@@ -26,6 +26,8 @@ const styles = {
       ${media40em} {
         perspective-origin: 50% -10%;
       }
+      height: 96vh;
+      overflow: hidden;
     }
     .tab {
       transition: transform 1s;


### PR DESCRIPTION
**What does this PR do?**
- It appeared as the content page on chrome was not fixed and made the footer appear bigger 
- as a quick solution, fixed the height of the page with vh unit 